### PR TITLE
feat: implement Hibernate cascades and DAO methods for User, Comment,…

### DIFF
--- a/src/main/java/core/basesyntax/dao/impl/CommentDaoImpl.java
+++ b/src/main/java/core/basesyntax/dao/impl/CommentDaoImpl.java
@@ -2,8 +2,12 @@ package core.basesyntax.dao.impl;
 
 import core.basesyntax.dao.CommentDao;
 import core.basesyntax.model.Comment;
+import core.basesyntax.model.Smile;
+import java.util.ArrayList;
 import java.util.List;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 
 public class CommentDaoImpl extends AbstractDao implements CommentDao {
     public CommentDaoImpl(SessionFactory sessionFactory) {
@@ -11,22 +15,72 @@ public class CommentDaoImpl extends AbstractDao implements CommentDao {
     }
 
     @Override
-    public Comment create(Comment entity) {
-        return null;
+    public Comment create(Comment comment) {
+        Transaction transaction = null;
+        Session session = null;
+        try {
+            session = factory.openSession();
+            transaction = session.beginTransaction();
+
+            List<Smile> inputSmiles = comment.getSmiles();
+            List<Smile> validatedSmiles = new ArrayList<>();
+
+            if (inputSmiles != null) {
+                for (Smile smile : inputSmiles) {
+                    Long id = smile.getId();
+                    if (id == null) {
+                        throw new RuntimeException("Only existing smiles allowed.");
+                    }
+                    Smile fromDb = session.get(Smile.class, id);
+                    if (fromDb == null) {
+                        throw new RuntimeException("Smile with ID " + id + " not found in DB.");
+                    }
+                    validatedSmiles.add(fromDb);
+                }
+            }
+
+            comment.setSmiles(validatedSmiles);
+            session.persist(comment);
+            transaction.commit();
+            return comment;
+        } catch (Exception e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            throw new RuntimeException("Can't create Comment entity", e);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
     }
 
     @Override
     public Comment get(Long id) {
-        return null;
+        try (Session session = factory.openSession()) {
+            return session.get(Comment.class, id);
+        } catch (Exception e) {
+            throw new RuntimeException("Can't get Comment entity by id " + id, e);
+        }
     }
 
     @Override
     public List<Comment> getAll() {
-        return null;
+        try (Session session = factory.openSession()) {
+            return session.createQuery("from Comment", Comment.class).list();
+        } catch (Exception e) {
+            throw new RuntimeException("Can't get all Comment entities", e);
+        }
     }
 
     @Override
     public void remove(Comment entity) {
-
+        try (Session session = factory.openSession()) {
+            Transaction transaction = session.beginTransaction();
+            session.remove(session.get(Comment.class, entity.getId()));
+            transaction.commit();
+        } catch (Exception e) {
+            throw new RuntimeException("Can't remove Comment entity", e);
+        }
     }
 }

--- a/src/main/java/core/basesyntax/dao/impl/MessageDaoImpl.java
+++ b/src/main/java/core/basesyntax/dao/impl/MessageDaoImpl.java
@@ -3,7 +3,9 @@ package core.basesyntax.dao.impl;
 import core.basesyntax.dao.MessageDao;
 import core.basesyntax.model.Message;
 import java.util.List;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 
 public class MessageDaoImpl extends AbstractDao implements MessageDao {
     public MessageDaoImpl(SessionFactory sessionFactory) {
@@ -11,22 +13,66 @@ public class MessageDaoImpl extends AbstractDao implements MessageDao {
     }
 
     @Override
-    public Message create(Message entity) {
-        return null;
+    public Message create(Message message) {
+        Transaction transaction = null;
+        Session session = null;
+        try {
+            session = factory.openSession();
+            transaction = session.beginTransaction();
+            session.persist(message);
+            transaction.commit();
+            return message;
+        } catch (Exception e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            throw new RuntimeException("Can't create Message entity", e);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
     }
 
     @Override
     public Message get(Long id) {
-        return null;
+        try (Session session = factory.openSession()) {
+            return session.get(Message.class, id);
+        } catch (Exception e) {
+            throw new RuntimeException("Can't get Message entity by id " + id, e);
+        }
     }
 
     @Override
     public List<Message> getAll() {
-        return null;
+        try (Session session = factory.openSession()) {
+            return session.createQuery("from Message", Message.class).list();
+        } catch (Exception e) {
+            throw new RuntimeException("Can't get all Message entities", e);
+        }
     }
 
     @Override
-    public void remove(Message entity) {
-
+    public void remove(Message message) {
+        Transaction transaction = null;
+        Session session = null;
+        try {
+            session = factory.openSession();
+            transaction = session.beginTransaction();
+            Message managedMessage = session.get(Message.class, message.getId());
+            if (managedMessage != null) {
+                session.remove(managedMessage);
+            }
+            transaction.commit();
+        } catch (Exception e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            throw new RuntimeException("Can't delete Message entity", e);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
     }
 }

--- a/src/main/java/core/basesyntax/dao/impl/MessageDetailsDaoImpl.java
+++ b/src/main/java/core/basesyntax/dao/impl/MessageDetailsDaoImpl.java
@@ -2,7 +2,9 @@ package core.basesyntax.dao.impl;
 
 import core.basesyntax.dao.MessageDetailsDao;
 import core.basesyntax.model.MessageDetails;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 
 public class MessageDetailsDaoImpl extends AbstractDao implements MessageDetailsDao {
     public MessageDetailsDaoImpl(SessionFactory sessionFactory) {
@@ -10,12 +12,31 @@ public class MessageDetailsDaoImpl extends AbstractDao implements MessageDetails
     }
 
     @Override
-    public MessageDetails create(MessageDetails entity) {
-        return null;
+    public MessageDetails create(MessageDetails messageDetails) {
+        Transaction transaction = null;
+        Session session = null;
+        try {
+            session = factory.openSession();
+            transaction = session.beginTransaction();
+            session.persist(messageDetails);
+            transaction.commit();
+            return messageDetails;
+        } catch (Exception e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            throw new RuntimeException("Can't create MessageDetails entity", e);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
     }
 
     @Override
     public MessageDetails get(Long id) {
-        return null;
+        try (Session session = factory.openSession()) {
+            return session.get(MessageDetails.class, id);
+        }
     }
 }

--- a/src/main/java/core/basesyntax/dao/impl/SmileDaoImpl.java
+++ b/src/main/java/core/basesyntax/dao/impl/SmileDaoImpl.java
@@ -3,7 +3,9 @@ package core.basesyntax.dao.impl;
 import core.basesyntax.dao.SmileDao;
 import core.basesyntax.model.Smile;
 import java.util.List;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 
 public class SmileDaoImpl extends AbstractDao implements SmileDao {
     public SmileDaoImpl(SessionFactory sessionFactory) {
@@ -12,16 +14,35 @@ public class SmileDaoImpl extends AbstractDao implements SmileDao {
 
     @Override
     public Smile create(Smile entity) {
-        return null;
+        Transaction transaction = null;
+        try (Session session = factory.openSession()) {
+            transaction = session.beginTransaction();
+            session.persist(entity);
+            transaction.commit();
+        } catch (Exception exception) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            throw new RuntimeException("Error while creating Smile entity", exception);
+        }
+        return entity;
     }
 
     @Override
     public Smile get(Long id) {
-        return null;
+        try (Session session = factory.openSession()) {
+            return session.get(Smile.class, id);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while getting Smile entity by id" + id, e);
+        }
     }
 
     @Override
     public List<Smile> getAll() {
-        return null;
+        try (Session session = factory.openSession()) {
+            return session.createQuery("from Smile", Smile.class).list();
+        } catch (Exception e) {
+            throw new RuntimeException("Error while getting all Smile entities", e);
+        }
     }
 }

--- a/src/main/java/core/basesyntax/dao/impl/UserDaoImpl.java
+++ b/src/main/java/core/basesyntax/dao/impl/UserDaoImpl.java
@@ -3,7 +3,10 @@ package core.basesyntax.dao.impl;
 import core.basesyntax.dao.UserDao;
 import core.basesyntax.model.User;
 import java.util.List;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
 import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
 
 public class UserDaoImpl extends AbstractDao implements UserDao {
     public UserDaoImpl(SessionFactory sessionFactory) {
@@ -12,21 +15,61 @@ public class UserDaoImpl extends AbstractDao implements UserDao {
 
     @Override
     public User create(User entity) {
-        return null;
+        Session session = null;
+        Transaction transaction = null;
+        try {
+            session = factory.openSession();
+            transaction = session.beginTransaction();
+            session.persist(entity);
+            transaction.commit();
+        } catch (Exception exception) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            throw new HibernateException("Error while creating User entity", exception);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
+        return entity;
     }
 
     @Override
     public User get(Long id) {
-        return null;
+        Session session = factory.openSession();
+        return session.get(User.class, id);
     }
 
     @Override
     public List<User> getAll() {
-        return null;
+        try (Session session = factory.openSession()) {
+            return session.createQuery("from User", User.class).list();
+        }
     }
 
     @Override
-    public void remove(User entity) {
-
+    public void remove(User user) {
+        Transaction transaction = null;
+        Session session = null;
+        try {
+            session = factory.openSession();
+            transaction = session.beginTransaction();
+            User managedUser = session.get(User.class, user.getId());
+            if (managedUser != null) {
+                session.remove(managedUser);
+            }
+            transaction.commit();
+        } catch (Exception e) {
+            if (transaction != null) {
+                transaction.rollback();
+            }
+            throw new RuntimeException("Can't delete User entity", e);
+        } finally {
+            if (session != null) {
+                session.close();
+            }
+        }
     }
+
 }

--- a/src/main/java/core/basesyntax/model/Comment.java
+++ b/src/main/java/core/basesyntax/model/Comment.java
@@ -1,15 +1,29 @@
 package core.basesyntax.model;
 
+import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
 import java.util.List;
 
+@Entity
+@Table(name = "comments")
 public class Comment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String content;
+
+    @ManyToMany
+    @JoinTable(
+            name = "comment_smiles",
+            joinColumns = @JoinColumn(name = "comment_id"),
+            inverseJoinColumns = @JoinColumn(name = "smile_id")
+    )
     private List<Smile> smiles;
 
     public Long getId() {

--- a/src/main/java/core/basesyntax/model/Message.java
+++ b/src/main/java/core/basesyntax/model/Message.java
@@ -1,8 +1,24 @@
 package core.basesyntax.model;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "messages")
 public class Message {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String content;
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_details_id")
     private MessageDetails messageDetails;
 
     public Long getId() {

--- a/src/main/java/core/basesyntax/model/MessageDetails.java
+++ b/src/main/java/core/basesyntax/model/MessageDetails.java
@@ -1,8 +1,17 @@
 package core.basesyntax.model;
 
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 
+@Entity
+@Table(name = "message_details")
 public class MessageDetails {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String sender;
     private LocalDateTime sentTime;

--- a/src/main/java/core/basesyntax/model/User.java
+++ b/src/main/java/core/basesyntax/model/User.java
@@ -1,11 +1,28 @@
 package core.basesyntax.model;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
 import java.util.List;
 
+@Entity
+@Table(name = "users")
 public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String username;
-    private List<Comment> comments;
+
+    @OneToMany(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id")
+    private List<Comment> comments = new ArrayList<>();
 
     public Long getId() {
         return id;

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -13,6 +13,11 @@
         <property name="show_sql">true</property>
         <property name="hbm2ddl.auto">update</property>
 
+        <mapping class="core.basesyntax.model.User"/>
+        <mapping class="core.basesyntax.model.Smile"/>
+        <mapping class="core.basesyntax.model.MessageDetails"/>
+        <mapping class="core.basesyntax.model.Message"/>
+        <mapping class="core.basesyntax.model.Comment"/>
 
     </session-factory>
 </hibernate-configuration>


### PR DESCRIPTION
- Configured proper cascade types and relationships for:
  - User -> Comment (CascadeType.PERSIST, no REMOVE cascade)
  - Comment -> Smile (no cascading to Smile, smiles are reused)
  - Message -> MessageDetails (CascadeType.ALL)
  
- Implemented remove(User user):
  - Removes the user without removing associated comments

- Implemented remove(Comment comment):
  - Removes the comment but keeps associated smiles in DB

- Implemented remove(Message message):
  - Removes the message and automatically deletes its details

- Implemented DAO methods for UserDao, CommentDao, SmileDao, and MessageDao

- Ensured that during creation:
  - New users persist their comments
  - New comments use existing smiles only
  - New messages create associated MessageDetails Smile, and Message